### PR TITLE
Fixes getProjectsPath() return value.

### DIFF
--- a/src/main.zsh
+++ b/src/main.zsh
@@ -71,7 +71,7 @@ getProjectsPath()
 
     if [[ -n ${projectsPath} ]]; then
         addDebug "Raw Projects Path:\n${projectsPath}"
-        projectsPath=$(xmlDecode $(echo ${projectsPath} | sed -e 's/ value="//g' -e 's/"/\n/g' -e "s/[$]USER_HOME[$]/${escapedHome}/g"))
+        projectsPath=$(xmlDecode $(echo ${projectsPath} | sed -e 's/ value="//g' -e 's/"/\\n/g' -e "s/[$]USER_HOME[$]/${escapedHome}/g"))
         addDebug "Projects Path:\n${projectsPath}"
     fi
 


### PR DESCRIPTION
Escapes \n on line 74 to eliminate appending 'n' at the end of each project's path.